### PR TITLE
Added default timeoutMs parameter to success and error status messages

### DIFF
--- a/BTProgressHUD/BTProgressHUD.cs
+++ b/BTProgressHUD/BTProgressHUD.cs
@@ -73,14 +73,14 @@ namespace BigTed
 			obj.InvokeOnMainThread (() => SharedView.SetStatusWorker (status));
 		}
 
-		public static void ShowSuccessWithStatus(string status)
+		public static void ShowSuccessWithStatus(string status, double timeoutMs = 1000)
 		{
-			ShowImage (UIImage.FromBundle ("success.png"), status);
+			ShowImage (UIImage.FromBundle ("success.png"), status, timeoutMs);
 		}
 
-		public static void ShowErrorWithStatus(string status)
+		public static void ShowErrorWithStatus(string status, double timeoutMs = 1000)
 		{
-			ShowImage (UIImage.FromBundle ("error.png"), status);
+			ShowImage (UIImage.FromBundle ("error.png"), status, timeoutMs);
 		}
 		public static void ShowImage(UIImage image, string status, double timeoutMs = 1000) 
 		{


### PR DESCRIPTION
Changed ShowSuccessWithStatus and ShowErrorWithStatus. Sometimes those messages might need to be displayed longer than 1000 ms.
