### PR TITLE
Added continuous progress option

### DIFF
--- a/BTProgressHUD.sln
+++ b/BTProgressHUD.sln
@@ -1,36 +1,30 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BTProgressHUDDemo", "BTProgressHUDDemo\BTProgressHUDDemo.csproj", "{E6E84D09-BE15-460D-A317-45248BE1C56F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BTProgressHUD", "BTProgressHUD\BTProgressHUD.csproj", "{173ADCB0-C964-48D2-99C1-E928469F7C53}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|iPhoneSimulator = Debug|iPhoneSimulator
-		Release|iPhoneSimulator = Release|iPhoneSimulator
-		Debug|iPhone = Debug|iPhone
-		Release|iPhone = Release|iPhone
 		Ad-Hoc|iPhone = Ad-Hoc|iPhone
+		Ad-Hoc|iPhoneSimulator = Ad-Hoc|iPhoneSimulator
 		AppStore|iPhone = AppStore|iPhone
+		AppStore|iPhoneSimulator = AppStore|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Ad-Hoc|iPhone.ActiveCfg = Release|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Ad-Hoc|iPhone.Build.0 = Release|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.AppStore|iPhone.ActiveCfg = Release|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.AppStore|iPhone.Build.0 = Release|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Release|iPhone.Build.0 = Release|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{E6E84D09-BE15-460D-A317-45248BE1C56F}.Ad-Hoc|iPhone.ActiveCfg = Ad-Hoc|iPhone
 		{E6E84D09-BE15-460D-A317-45248BE1C56F}.Ad-Hoc|iPhone.Build.0 = Ad-Hoc|iPhone
+		{E6E84D09-BE15-460D-A317-45248BE1C56F}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Ad-Hoc|iPhoneSimulator
+		{E6E84D09-BE15-460D-A317-45248BE1C56F}.Ad-Hoc|iPhoneSimulator.Build.0 = Ad-Hoc|iPhoneSimulator
 		{E6E84D09-BE15-460D-A317-45248BE1C56F}.AppStore|iPhone.ActiveCfg = AppStore|iPhone
 		{E6E84D09-BE15-460D-A317-45248BE1C56F}.AppStore|iPhone.Build.0 = AppStore|iPhone
+		{E6E84D09-BE15-460D-A317-45248BE1C56F}.AppStore|iPhoneSimulator.ActiveCfg = AppStore|iPhoneSimulator
+		{E6E84D09-BE15-460D-A317-45248BE1C56F}.AppStore|iPhoneSimulator.Build.0 = AppStore|iPhoneSimulator
 		{E6E84D09-BE15-460D-A317-45248BE1C56F}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{E6E84D09-BE15-460D-A317-45248BE1C56F}.Debug|iPhone.Build.0 = Debug|iPhone
 		{E6E84D09-BE15-460D-A317-45248BE1C56F}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
@@ -39,6 +33,23 @@ Global
 		{E6E84D09-BE15-460D-A317-45248BE1C56F}.Release|iPhone.Build.0 = Release|iPhone
 		{E6E84D09-BE15-460D-A317-45248BE1C56F}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
 		{E6E84D09-BE15-460D-A317-45248BE1C56F}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Ad-Hoc|iPhone.ActiveCfg = Release|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Ad-Hoc|iPhone.Build.0 = Release|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.AppStore|iPhone.ActiveCfg = Release|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.AppStore|iPhone.Build.0 = Release|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.AppStore|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Release|iPhone.Build.0 = Release|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{173ADCB0-C964-48D2-99C1-E928469F7C53}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = BTProgressHUDDemo\BTProgressHUDDemo.csproj

--- a/BTProgressHUD/BTProgressHUD.csproj
+++ b/BTProgressHUD/BTProgressHUD.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -23,6 +23,16 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
+    <MtouchSdkVersion>6.1</MtouchSdkVersion>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchDebug>False</MtouchDebug>
+    <MtouchProfiling>False</MtouchProfiling>
+    <MtouchExtraArgs />
+    <MtouchArch>Default, ARMv7</MtouchArch>
+    <MtouchUseLlvm>False</MtouchUseLlvm>
+    <MtouchUseThumb>False</MtouchUseThumb>
+    <MtouchUseSGen>False</MtouchUseSGen>
+    <MtouchUseRefCounting>False</MtouchUseRefCounting>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -41,7 +51,7 @@
   <ItemGroup>
     <Folder Include="Resources\" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
     <BundleResource Include="error.png" />
     <BundleResource Include="error%402x.png" />
@@ -50,5 +60,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BTProgressHUD.cs" />
+    <Compile Include="Ring.cs" />
   </ItemGroup>
 </Project>

--- a/BTProgressHUD/Ring.cs
+++ b/BTProgressHUD/Ring.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using MonoTouch.UIKit;
+
+namespace BigTed
+{
+    public class Ring
+    {
+        /// <summary>
+        /// Ring color
+        /// </summary>
+        public UIColor Color = UIColor.White;
+
+        /// <summary>
+        /// Background color
+        /// </summary>
+        public UIColor BackgroundColor = UIColor.DarkGray;
+
+        /// <summary>
+        /// Progress update interval in milliseconds
+        /// </summary>
+        public Double ProgressUpdateInterval = 300;
+    }
+}

--- a/BTProgressHUDDemo/BTProgressHUDDemo.csproj
+++ b/BTProgressHUDDemo/BTProgressHUDDemo.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -92,7 +92,7 @@
     <Compile Include="AppDelegate.cs" />
     <Compile Include="MainView.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\BTProgressHUD\BTProgressHUD.csproj">
       <Project>{173ADCB0-C964-48D2-99C1-E928469F7C53}</Project>

--- a/BTProgressHUDDemo/Info.plist
+++ b/BTProgressHUDDemo/Info.plist
@@ -22,5 +22,17 @@
 	</array>
 	<key>MinimumOSVersion</key>
 	<string>3.2</string>
+	<key>CFBundleDisplayName</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string></string>
+	<key>CFBundleVersion</key>
+	<string></string>
+	<key>NSMainNibFile</key>
+	<string></string>
+	<key>NSMainNibFile~ipad</key>
+	<string></string>
+	<key>MKDirectionsApplicationSupportedModes</key>
+	<array/>
 </dict>
 </plist>

--- a/BTProgressHUDDemo/MainView.cs
+++ b/BTProgressHUDDemo/MainView.cs
@@ -58,6 +58,19 @@ namespace BTProgressHUDDemo
 				KillAfter ();
 			});
 
+            MakeButton("Show Continuous Progress", () =>
+            {
+                /* Default values below
+                BTProgressHUD.Ring.Color = UIColor.White;
+                BTProgressHUD.Ring.BackgroundColor = UIColor.DarkGray;
+                BTProgressHUD.Ring.ProgressUpdateInterval = 300;
+                */
+
+                BTProgressHUD.Ring.Color = UIColor.Green;
+                BTProgressHUD.ShowContinuousProgress("Continuous progress...");
+                KillAfter(3);
+            });
+
 			MakeButton ("Show Success", () => {
 				BTProgressHUD.ShowSuccessWithStatus("Great success!") ;
 			});


### PR DESCRIPTION
Added continuous progress option that allows user to configure Ring color, ring background color and progress update interval. In my app I don't want to be updating the progress indicator so this option keeps the ring progress moving until I call BTProgressHUD.Dismiss(). I also added configurable ring and ring background color as well as the progress update interval.

Example:

``` C#
BTProgressHUD.Ring.Color = UIColor.White;
BTProgressHUD.Ring.BackgroundColor = UIColor.DarkGray;
BTProgressHUD.Ring.ProgressUpdateInterval = 300;
BTProgressHUD.ShowContinuousProgress("Continuous progress...");
```

Here are some screenshots from code running on iPod and iPad with a green ring.
![img_0075](https://f.cloud.github.com/assets/1189224/950612/299cbe92-0392-11e3-9dc3-c6c17c63a8f8.PNG)
![img_0300](https://f.cloud.github.com/assets/1189224/950613/2c5108dc-0392-11e3-8156-74151ae55326.PNG)

Let me know what you think of this pull. Thanks Nic
