### PR TITLE
Modified UIWindow iteration at the start of the ProgressHUD.ShowProgress...

### DIFF
--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -187,9 +187,10 @@ namespace BigTed
 				Array.Reverse (windows);
 				foreach (UIWindow window in windows)
 				{
-					if (window.WindowLevel == UIWindow.LevelNormal)
+					if (window.WindowLevel == UIWindow.LevelNormal && !window.Hidden)
 					{
 						window.AddSubview (OverlayView);
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
...Worker method.

My Windows array contained two instances.  Instance 0 was hidden, while instance 1 wasn't.
The previous code first assigned the overlay view to the visible window, then reassigned it to the
hidden one, causing the progress hud to also be hidden.
