### PR TITLE
Fixed toast displayed behind the keyboard if already popped.

### DIFF
--- a/BTProgressHUD/BTProgressHUD.csproj
+++ b/BTProgressHUD/BTProgressHUD.csproj
@@ -44,6 +44,7 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
     <Compile Include="BTProgressHUD.cs" />
+    <Compile Include="NSObjectExtensions.cs" />
     <Compile Include="ProgressHUD.cs" />
     <Compile Include="Ring.cs" />
     <Compile Include="XHUD.cs" />

--- a/BTProgressHUD/NSObjectExtensions.cs
+++ b/BTProgressHUD/NSObjectExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+
+namespace BigTed
+{
+    /// <summary>
+    /// Contains several extensions for NSObject and derived classes.
+    /// </summary>
+    public static class NSObjectExtensions
+    {
+
+        [DllImport("/usr/lib/libobjc.dylib")]
+        private static extern IntPtr object_getClassName(IntPtr obj);
+
+        /// <summary>
+        /// Returns the Objective-C class name of the NSObject instance.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public static string GetClassName(this NSObject obj)
+        {
+            return Marshal.PtrToStringAuto(object_getClassName(obj.Handle));
+        }
+
+    }
+}

--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -682,32 +682,26 @@ namespace BigTed
 
 		float VisibleKeyboardHeight
 		{
-			get
-			{
-				UIWindow keyboardWindow = null;
-				foreach (var testWindow in UIApplication.SharedApplication.Windows)
-				{
-					if (!(testWindow is UIWindow))
-					{
-						keyboardWindow = testWindow;
-						break;
-					}
-				}
+            get
+            {
+                foreach (var testWindow in UIApplication.SharedApplication.Windows)
+                {
+                    if (testWindow.GetClassName() != typeof(UIWindow).Name)
+                    {
+                        foreach (var possibleKeyboard in testWindow.Subviews)
+                        {
+                            var nativeViewName = possibleKeyboard.GetClassName();
+                            if (nativeViewName == "UIPeripheralHostView" ||
+                                nativeViewName == "UIKeyboard")
+                            {
+                                return possibleKeyboard.Bounds.Size.Height;
+                            }
+                        }
+                    }
+                }
 
-				if (keyboardWindow == null)
-					return 0;
-
-				foreach (var possibleKeyboard in keyboardWindow.Subviews)
-				{
-					if (possibleKeyboard.GetType().Name == "UIPeripheralHostView" ||
-					    possibleKeyboard.GetType().Name == "UIKeyboard")
-					{
-						return possibleKeyboard.Bounds.Size.Height;
-					}
-				}
-
-				return 0;
-			}
+                return 0;
+            }
 		}
 
 		void DismissWorker()


### PR DESCRIPTION
If show request is done while keyboard is already popped, it will not be detected and the toast will not be visible to the user.
The way used to detect the keyboard seems to not follow Apple recommendation, but it was the easy way to go instead of listening for keyboard notification all the application lifetime long... (as done in the original implementation)
