### PR TITLE
Updated iOS Unified API Support

### DIFF
--- a/ComponentStoreAssets/btprogresshud/component.yaml
+++ b/ComponentStoreAssets/btprogresshud/component.yaml
@@ -1,4 +1,4 @@
-version: "1.14"
+version: "1.15"
 name: BTProgressHUD
 id: btprogresshud
 publisher: Nic Wise / Big Ted Ltd

--- a/samples/BTProgressHUDSample/BTProgressHUDSample/Info.plist
+++ b/samples/BTProgressHUDSample/BTProgressHUDSample/Info.plist
@@ -22,7 +22,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>5.0</string>
+	<string>5.2</string>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
 	<key>XSLaunchImageAssets</key>


### PR DESCRIPTION
Had to have Unified sample target >= iOS 5.1.1

Submitted as v1.15 to the component store so it's good to be reviewed and ready to release on Jan 5th.
