### PR TITLE
Allow restricting HUD to a parent view.

### DIFF
--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -39,10 +39,9 @@ namespace BigTed
 {
 	public class ProgressHUD : UIView
 	{
-		public ProgressHUD (UIView parentContainer)
+		public ProgressHUD (UIView parentContainer) : this (parentContainer.Bounds)
 		{
 			ParentContainer = parentContainer;
-			Initialize ();
 		}
 
 		public ProgressHUD () : this (UIScreen.MainScreen.Bounds)
@@ -50,11 +49,6 @@ namespace BigTed
 		}
 
 		public ProgressHUD (CGRect frame) : base (frame)
-		{
-			Initialize ();
-		}
-
-		void Initialize ()
 		{
 			UserInteractionEnabled = false;
 			BackgroundColor = UIColor.Clear;

--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -304,6 +304,9 @@ namespace BigTed
 				};
 			}
 
+			if (ParentContainer != null) {
+				Frame = ParentContainer.Bounds;
+			}
 			UpdatePosition (textOnly);
 
 			if (showContinuousProgress)
@@ -581,7 +584,8 @@ namespace BigTed
 			{
 				if (_overlayView == null)
 				{
-					_overlayView = new UIView (UIScreen.MainScreen.Bounds);
+					var overlayBounds = ParentContainer != null ? ParentContainer.Bounds : UIScreen.MainScreen.Bounds;
+					_overlayView = new UIView (overlayBounds);
 					_overlayView.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
 					_overlayView.BackgroundColor = UIColor.Clear;
 					_overlayView.UserInteractionEnabled = false;
@@ -852,7 +856,9 @@ namespace BigTed
 			nfloat keyboardHeight = 0;
 			double animationDuration = 0;
 
-			Frame = UIScreen.MainScreen.Bounds;
+			// Make sure we account for parent size changing (e.g., TabBar/StatusBar auto-adjustments).
+			var frame = ParentContainer != null ? ParentContainer.Bounds : UIScreen.MainScreen.Bounds;
+			Frame = frame;
 
 			UIInterfaceOrientation orientation = UIApplication.SharedApplication.StatusBarOrientation;
 			bool ignoreOrientation = UIDevice.CurrentDevice.CheckSystemVersion (8, 0);

--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -39,11 +39,22 @@ namespace BigTed
 {
 	public class ProgressHUD : UIView
 	{
+		public ProgressHUD (UIView parentContainer)
+		{
+			ParentContainer = parentContainer;
+			Initialize ();
+		}
+
 		public ProgressHUD () : this (UIScreen.MainScreen.Bounds)
 		{
 		}
 
 		public ProgressHUD (CGRect frame) : base (frame)
+		{
+			Initialize ();
+		}
+
+		void Initialize ()
 		{
 			UserInteractionEnabled = false;
 			BackgroundColor = UIColor.Clear;
@@ -96,6 +107,7 @@ namespace BigTed
 		public UITextAlignment HudTextAlignment = UITextAlignment.Center;
 		public Ring Ring = new Ring ();
 		static NSObject obj = new NSObject ();
+		public UIView ParentContainer;
 
 		public void Show (string status = null, float progress = -1, MaskType maskType = MaskType.None, double timeoutMs = 1000)
 		{
@@ -255,14 +267,20 @@ namespace BigTed
 
 			if (OverlayView.Superview == null)
 			{
-				var windows = UIApplication.SharedApplication.Windows;
-				Array.Reverse (windows);
-				foreach (UIWindow window in windows)
+				if (ParentContainer != null)
 				{
-					if (window.WindowLevel == UIWindowLevel.Normal && !window.Hidden)
+					ParentContainer.AddSubview (OverlayView);
+				}
+				else {
+					var windows = UIApplication.SharedApplication.Windows;
+					Array.Reverse (windows);
+					foreach (UIWindow window in windows)
 					{
-						window.AddSubview (OverlayView);
-						break;
+						if (window.WindowLevel == UIWindowLevel.Normal && !window.Hidden)
+						{
+							window.AddSubview (OverlayView);
+							break;
+						}
 					}
 				}
 			}

--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -882,7 +882,7 @@ namespace BigTed
 				keyboardHeight = VisibleKeyboardHeight;
 			}
 			
-			CGRect orientationFrame = this.Window.Bounds;
+			CGRect orientationFrame = ParentContainer != null ? ParentContainer.Bounds : this.Window.Bounds;
 			CGRect statusBarFrame = UIApplication.SharedApplication.StatusBarFrame;
 			
 			if (!ignoreOrientation && IsLandscape (orientation))


### PR DESCRIPTION
- [x] Allow a constructor to be called with a parent view that will contain the mask overlay (allowing HUD within a tab, for instance).
- [ ] Figure out a good way to interact the parent view system with the static `Show` methods.
- [ ] Test that combining `Show` calls with a parent and without a parent doesn't blow up the world.

(Note: I wasn't sure where to send the PR, but this looked like the in-progress branch so I went for it. I can always cherry-pick it to a master-derived branch, though.)
