### PR TITLE
Support for dark mode

### DIFF
--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -1,4 +1,4 @@
-// BTProgressHUD - port of SVProgressHUD
+﻿// BTProgressHUD - port of SVProgressHUD
 //
 //  https://github.com/nicwise/BTProgressHUD
 // 
@@ -87,9 +87,9 @@ namespace BigTed
 		{
 
 			if (IsiOS7ForLookAndFeel) {
-				HudBackgroundColour = UIColor.White.ColorWithAlpha (0.8f);
-				HudForegroundColor = UIColor.FromWhiteAlpha (0.0f, 0.8f);
-				HudStatusShadowColor = UIColor.FromWhiteAlpha (200f / 255f, 0.8f);
+				HudBackgroundColour = UIColor.SystemBackgroundColor.ColorWithAlpha (0.8f);
+				HudForegroundColor = UIColor.LabelColor.ColorWithAlpha(0.8f);
+				HudStatusShadowColor = UIColor.LabelColor.ColorWithAlpha(0.8f);
 				_ringThickness = 1f;
 
 			} else {

--- a/BTProgressHUD/Ring.cs
+++ b/BTProgressHUD/Ring.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 #if __UNIFIED__
 using UIKit;
@@ -26,7 +26,7 @@ namespace BigTed
 		public void ResetStyle(bool isiOS7, UIColor colorToUse)
 		{
 			Color = colorToUse;
-			BackgroundColor = isiOS7 ? UIColor.White : UIColor.DarkGray;
+			BackgroundColor = isiOS7 ? UIColor.SystemBackgroundColor : UIColor.DarkGray;
 			ProgressUpdateInterval = 300;
 
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Added support for dark mode. The background color of the modal will be black and the label color white when the user is in dark mode. Added for both the HUD itself and for the progress ring.

### :arrow_heading_down: What is the current behavior?
Colors are hardcoded to be black text on white background, even when the device is in dark mode.

### :new: What is the new behavior (if this is a feature change)?
Dynamically uses the preferred background/foreground colors.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Run the samples app in both light and dark mode. Check that dark mode dynamically switches colors and that light mode behaves as expected.

### :memo: Links to relevant issues/docs
Screenshots for dark mode:
![Simulator Screen Shot - iPhone 11 Pro Max - 2019-12-13 at 00 09 40](https://user-images.githubusercontent.com/11583629/70756673-774d8100-1d3d-11ea-8f23-f718e1a33daa.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2019-12-13 at 00 09 47](https://user-images.githubusercontent.com/11583629/70756678-7a487180-1d3d-11ea-95ee-7274dcdba531.png)


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
