### PR TITLE
Fix for Success, Error Images not Showing up

### DIFF
--- a/BTProgressHUD/BTProgressHUD.csproj
+++ b/BTProgressHUD/BTProgressHUD.csproj
@@ -10,7 +10,36 @@
   <ItemGroup>
 	  <BundleResource Include="**\*.png" />
 	  <None Include="..\NOTICE" pack="true" PackagePath="" />
-    <None Include="..\LICENSE" Pack="true" PackagePath=""/>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
   
+  <ItemGroup>
+    <BundleResource Update="success%402x.png">
+      <IncludeInPackage>true</IncludeInPackage>
+    </BundleResource>
+    <BundleResource Update="success_7%402x.png">
+      <IncludeInPackage>true</IncludeInPackage>
+    </BundleResource>
+    <BundleResource Update="xamarin%402x.png">
+      <IncludeInPackage>true</IncludeInPackage>
+    </BundleResource>
+    <BundleResource Update="error.png">
+      <IncludeInPackage>true</IncludeInPackage>
+    </BundleResource>
+    <BundleResource Update="error_7%402x.png">
+      <IncludeInPackage>true</IncludeInPackage>
+    </BundleResource>
+    <BundleResource Update="success.png">
+      <IncludeInPackage>true</IncludeInPackage>
+    </BundleResource>
+    <BundleResource Update="success_7.png">
+      <IncludeInPackage>true</IncludeInPackage>
+    </BundleResource>
+    <BundleResource Update="xamarin.png">
+      <IncludeInPackage>true</IncludeInPackage>
+    </BundleResource>
+    <BundleResource Update="error_7.png">
+      <IncludeInPackage>true</IncludeInPackage>
+    </BundleResource>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix

### :arrow_heading_down: What is the current behavior?
Success and Error Images are not showing because they don't get included in the nuget package.

### :new: What is the new behavior (if this is a feature change)?
Success and Error Images are now showing up correctly.

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Build and publish a lcoal nuget package and try calling ShowSuccessWithStatus or ShowErrorWithStatus and check if images are showing up correctly.

### :memo: Links to relevant issues/docs
#64

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
