### PR TITLE
Added Support for MaskType in ShowImage

### DIFF
--- a/BTProgressHUD/BTProgressHUD.cs
+++ b/BTProgressHUD/BTProgressHUD.cs
@@ -45,19 +45,19 @@ namespace BigTed
 			ProgressHUD.Shared.SetStatus(status);
 		}
 
-		public static void ShowSuccessWithStatus(string status, double timeoutMs = 1000)
+		public static void ShowSuccessWithStatus(string status, ProgressHUD.MaskType maskType = ProgressHUD.MaskType.None, double timeoutMs = 1000)
 		{
-			ProgressHUD.Shared.ShowSuccessWithStatus(status, timeoutMs);
+			ProgressHUD.Shared.ShowSuccessWithStatus(status, maskType, timeoutMs);
 		}
 
-		public static void ShowErrorWithStatus(string status, double timeoutMs = 1000)
+		public static void ShowErrorWithStatus(string status, ProgressHUD.MaskType maskType = ProgressHUD.MaskType.None, double timeoutMs = 1000)
 		{
-			ProgressHUD.Shared.ShowErrorWithStatus(status, timeoutMs);
+			ProgressHUD.Shared.ShowErrorWithStatus(status, maskType, timeoutMs);
 		}
 
-		public static void ShowImage(UIImage image, string status, double timeoutMs = 1000)
+		public static void ShowImage(UIImage image, string status, ProgressHUD.MaskType maskType = ProgressHUD.MaskType.None, double timeoutMs = 1000)
 		{
-			ProgressHUD.Shared.ShowImage(image, status, timeoutMs);
+			ProgressHUD.Shared.ShowImage(image, status, maskType, timeoutMs);
 		}
 
 		public static void Dismiss()

--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -163,20 +163,19 @@ namespace BigTed
             obj.InvokeOnMainThread(() => SetStatusWorker(status));
         }
 
-        public void ShowSuccessWithStatus(string status, double timeoutMs = 1000)
+        public void ShowSuccessWithStatus(string status, MaskType maskType = MaskType.None, double timeoutMs = 1000)
         {
-            ShowImage(SuccessImage, status, timeoutMs);
+            ShowImage(SuccessImage, status, maskType, timeoutMs);
         }
 
-        public void ShowErrorWithStatus(string status, double timeoutMs = 1000)
+        public void ShowErrorWithStatus(string status, MaskType maskType = MaskType.None, double timeoutMs = 1000)
         {
-            ShowImage(ErrorImage, status, timeoutMs);
+            ShowImage(ErrorImage, status, maskType, timeoutMs);
         }
 
-        public void ShowImage(UIImage image, string status, double timeoutMs = 1000)
+        public void ShowImage(UIImage image, string status, MaskType maskType = MaskType.None, double timeoutMs = 1000)
         {
-
-            obj.InvokeOnMainThread(() => ShowImageWorker(image, status, TimeSpan.FromMilliseconds(timeoutMs)));
+            obj.InvokeOnMainThread(() => ShowImageWorker(image, status, maskType, TimeSpan.FromMilliseconds(timeoutMs)));
         }
 
         public void Dismiss()
@@ -419,7 +418,7 @@ namespace BigTed
             }
         }
 
-        void ShowImageWorker(UIImage image, string status, TimeSpan duration)
+        void ShowImageWorker(UIImage image, string status, MaskType maskType, TimeSpan duration)
         {
 
             _progress = -1;
@@ -434,7 +433,7 @@ namespace BigTed
             }
 
             if (!IsVisible)
-                Show();
+                Show(null, -1F, maskType);
 
             ImageView.TintColor = HudForegroundColor;
             ImageView.Image = image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);

--- a/samples/BTProgressHUDSample/BTProgressHUDSample/MainView.cs
+++ b/samples/BTProgressHUDSample/BTProgressHUDSample/MainView.cs
@@ -28,7 +28,7 @@ namespace BTProgressHUDDemo
 		public override void LoadView()
 		{
 			base.LoadView();
-			View.BackgroundColor = UIColor.LightGray;
+			View.BackgroundColor = UIColor.White;
 
 			MakeButton("Run first - off main thread", () =>
 			{
@@ -90,8 +90,7 @@ namespace BTProgressHUDDemo
 
 			});
 
-
-			MakeButton("Dismiss", () =>
+            MakeButton("Dismiss", () =>
 			{
 				BTProgressHUD.Dismiss(); 
 			});
@@ -128,6 +127,14 @@ namespace BTProgressHUDDemo
 				BTProgressHUD.Dismiss(); 
 			});
 
+            // This demo only works on iOS 13 and above because of UIImage.GetSystemImage
+            // But it should work with versions below if you just use a UIImage
+            if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+            {
+                MakeButton("Success With Status", () =>
+                    BTProgressHUD.ShowImage(UIImage.GetSystemImage("photo"),"Success with image", ProgressHUD.MaskType.Black, 4000f)
+                );
+            }
 		}
 
 		void KillAfter(float timeout = 5)
@@ -171,18 +178,6 @@ namespace BTProgressHUDDemo
 
             previousButton = button;
 		}
-
-		public override void ViewDidLoad()
-		{
-			base.ViewDidLoad();
-		
-		}
-
-		public override void ViewDidAppear(bool animated)
-		{
-			base.ViewDidAppear(animated);
-
-		}
-	}
+    }
 }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
MaskType were not supported With `ShowImage`


### :arrow_heading_down: What is the current behavior?
ShowImage shows no MaskType

### :new: What is the new behavior (if this is a feature change)?
MaskType is now supported in `ShowImage`


### :boom: Does this PR introduce a breaking change?
`ShowSuccessWithStatus`, `ShowErrorWithStatus` and `ShowImage` needs to update there methods to include MaskType

### :bug: Recommendations for testing
Start the Demo project and select the last button, It should have a MaskType.Black, change it in de code to ProgressHUD.MaskType.Gradient and see the magic ✨ 

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- ✅  All projects build
- ✅  Follows style guide lines 
- ✅  Relevant documentation was updated (not needed)
- ✅  Rebased onto current develop
