### PR TITLE
Fix more KeyWindow usage

### DIFF
--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -869,7 +869,7 @@ namespace BTProgressHUD
                 keyboardHeight = VisibleKeyboardHeight;
             }
 
-            CGRect orientationFrame = UIApplication.SharedApplication.KeyWindow.Bounds;
+            CGRect orientationFrame = GetActiveWindow().Bounds;
 
             CGRect statusBarFrame = UIApplication.SharedApplication.StatusBarFrame;
 

--- a/samples/BTProgressHUDSample/BTProgressHUDSample/AppDelegate.cs
+++ b/samples/BTProgressHUDSample/BTProgressHUDSample/AppDelegate.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Threading.Tasks;
 using Foundation;
 using UIKit;
 
@@ -39,6 +39,13 @@ namespace BTProgressHUDDemo
 
 			// make the window visible
 			window.MakeKeyAndVisible ();
+            
+            BTProgressHUD.BTProgressHUD.Show("Cancel", () => { }, "Startup");
+            Task.Run(async () =>
+            {
+                await Task.Delay(2000);
+                BTProgressHUD.BTProgressHUD.Dismiss();
+            });
 			
 			return true;
 		}


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Already did some changes in PR#85 to fix issues on newer iOS versions as the API on how to get the current Window changed. However, I had missed an instance of usage of KeyWindow. This could potentially lead to cases where the Window would be null as described in #84.

### :new: What is the new behavior (if this is a feature change)?
Use the same GetActiveWindow method, which much better finds the active Window.

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
Try start the playground

### :memo: Links to relevant issues/docs
Fixes #84 

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
