### PR TITLE
Migrate to Xamarin.Legacy.Sdk, add .NET 6 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,18 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Setup .NET Core
+    - name: Setup .NET 5
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.401
+        dotnet-version: 5.0.x
+
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Install iOS workload
+      run: dotnet workload install ios
 
     - name: Run the Cake script
       uses: cake-build/cake-action@v1

--- a/BTProgressHUD/BTProgressHUD.csproj
+++ b/BTProgressHUD/BTProgressHUD.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>BigTed</RootNamespace>
     <PackageId>BTProgressHUD</PackageId>
     <Description>BTProgressHUD is a clean and easy-to-use HUD meant to display the progress of an ongoing task.</Description>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BTProgressHUD/BTProgressHUD.csproj
+++ b/BTProgressHUD/BTProgressHUD.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFramework>xamarin.ios10</TargetFramework>
+    <TargetFrameworks>xamarin.ios10;net6.0-ios</TargetFrameworks>
     <AssemblyName>BTProgressHUD</AssemblyName>
     <RootNamespace>BigTed</RootNamespace>
     <PackageId>BTProgressHUD</PackageId>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "3.0.38"
+    "Xamarin.Legacy.Sdk": "0.1.2-alpha6"
   }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

The project cannot be used on .NET 6 anymore due to [breaking changes](https://github.com/xamarin/xamarin-macios/issues/13087).

### :new: What is the new behavior (if this is a feature change)?

Builds NuGet with both legacy Xamarin.iOS and .NET 6 iOS binaries.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
