### PR TITLE
Fix crash on iOS 15 when showing HUD while app is moving to the foreground

### DIFF
--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -1138,7 +1138,17 @@ namespace BigTed
             }
             
             var windows = UIApplication.SharedApplication.Windows;
-            return windows.LastOrDefault(w => w.WindowLevel == UIWindowLevel.Normal && !w.Hidden && w.IsKeyWindow);
+            var window = windows.LastOrDefault(w => w.WindowLevel == UIWindowLevel.Normal && !w.Hidden && w.IsKeyWindow);
+
+            // As a last resort, if there's just 1 window, use that one.
+            // In iOS 15, showing the HUD while the app is moving to the foreground sometimes
+            // leads to this method getting called in a condition where
+            // UIWindowScene.ActivationState == UISceneActivationStateForegroundInactive
+            // and there is no window with IsKeyWindow == true
+            if (window == null && windows.Length == 1)
+                window = windows[0];
+
+            return window ?? throw new Exception("Could not find active window");
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

When the HUD is shown within UIApplicationDelegate.WillEnterForeground(), sometime an exception is thrown, making the app crash. I could not find a way to reproduce the issue, but I have almost 2,000 crash reports proving it does go wrong.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Unfortunately, I could not find a way to reproduce, so I can only recommend code review.

### :memo: Links to relevant issues/docs

Related to #84
