### PR TITLE
Fix issue when using Clear HudBackgroundColor

### DIFF
--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -255,15 +255,28 @@ namespace BigTed
                 if (_hudView != null)
                     return _hudView;
 
-                var hudView = new UIToolbar
+                UIView hudView;
+                if (ProgressHUDAppearance.HudBackgroundColor.Equals(UIColor.Clear))
                 {
-                    Translucent = true,
-                    BarTintColor = ProgressHUDAppearance.HudBackgroundColor,
-                    BackgroundColor = ProgressHUDAppearance.HudBackgroundColor,
-                    AutoresizingMask =
-                        UIViewAutoresizing.FlexibleBottomMargin | UIViewAutoresizing.FlexibleTopMargin |
-                        UIViewAutoresizing.FlexibleRightMargin | UIViewAutoresizing.FlexibleLeftMargin
-                };
+                    hudView = new UIView
+                    {
+                        BackgroundColor = ProgressHUDAppearance.HudBackgroundColor
+                    };
+                }
+                else
+                {
+                    hudView = new UIToolbar
+                    {
+                        Translucent = true,
+                        BarTintColor = ProgressHUDAppearance.HudBackgroundColor,
+                        BackgroundColor = ProgressHUDAppearance.HudBackgroundColor
+                    };    
+                }
+
+                hudView.AutoresizingMask =
+                    UIViewAutoresizing.FlexibleBottomMargin | UIViewAutoresizing.FlexibleTopMargin |
+                    UIViewAutoresizing.FlexibleRightMargin | UIViewAutoresizing.FlexibleLeftMargin;
+                
                 hudView.Layer.CornerRadius = ProgressHUDAppearance.HudCornerRadius;
                 hudView.Layer.MasksToBounds = true;
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
When using UIColor.Clear as background color, since the background of the view is a UIToolbar internally, it becomes black. Probably because it is trying to apply blur effects which it cannot when using a fully transparent color.

### :new: What is the new behavior (if this is a feature change)?
When color is Clear I swap to a regular UIView instead.

### :boom: Does this PR introduce a breaking change?
Not unless you are relying on Clear color to make the View black

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #109 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
