### PR TITLE
Don't access property getters in Remove methods

### DIFF
--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -698,18 +698,20 @@ namespace BigTed
         {
             CATransaction.Begin();
             CATransaction.DisableActions = true;
-            HudView.Layer.RemoveAllAnimations();
+            _hudView?.Layer.RemoveAllAnimations();
 
-            RingLayer.StrokeEnd = 0;
-            if (RingLayer.SuperLayer != null)
+            if (_ringLayer != null)
+                _ringLayer.StrokeEnd = 0;
+            
+            if (_ringLayer?.SuperLayer != null)
             {
-                RingLayer.RemoveFromSuperLayer();
+                _ringLayer.RemoveFromSuperLayer();
             }
             _ringLayer = null;
 
-            if (BackgroundRingLayer?.SuperLayer != null)
+            if (_backgroundRingLayer?.SuperLayer != null)
             {
-                BackgroundRingLayer.RemoveFromSuperLayer();
+                _backgroundRingLayer.RemoveFromSuperLayer();
             }
             _backgroundRingLayer = null;
 

--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -102,7 +102,7 @@ namespace BigTed
             AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
         }
 
-        public UIWindow HudWindow { get; private set; }
+        public UIWindow? HudWindow { get; private set; }
 
         public static CGRect KeyboardSize { get; private set; } = CGRect.Empty;
 
@@ -774,6 +774,7 @@ namespace BigTed
             try
             {
                 HudWindow?.RootViewController?.SetNeedsStatusBarAppearanceUpdate();
+                HudWindow = null!;
             }
             catch (ObjectDisposedException)
             {

--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -745,16 +745,17 @@ namespace BigTed
         private void RemoveHud()
         {
             Alpha = 0f;
-            HudView.Alpha = 0f;
+            if (_hudView != null)
+                _hudView.Alpha = 0f;
 
             //Removing observers
             UnRegisterNotifications();
             NSNotificationCenter.DefaultCenter.RemoveObserver(this);
 
             CancelRingLayerAnimation();
-            StringLabel.RemoveFromSuperview();
-            SpinnerView.RemoveFromSuperview();
-            ImageView.RemoveFromSuperview();
+            _stringLabel?.RemoveFromSuperview();
+            _spinnerView?.RemoveFromSuperview();
+            _imageView?.RemoveFromSuperview();
             _cancelHud?.RemoveFromSuperview();
 
             _stringLabel = null;
@@ -762,9 +763,9 @@ namespace BigTed
             _imageView = null;
             _cancelHud = null;
 
-            HudView.RemoveFromSuperview();
+            _hudView?.RemoveFromSuperview();
             _hudView = null;
-            OverlayView.RemoveFromSuperview();
+            _overlayView?.RemoveFromSuperview();
             _overlayView = null;
             RemoveFromSuperview();
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Still getting ObjectDisposedExceptions, which got better in #118, however still reproducible in some cases.

### :new: What is the new behavior (if this is a feature change)?
Fixed access to properties in Remove methods which would trigger implicit initialization of various views and attempt to access disposed references.

Also nulling out HudWindow in the remove hud method to avoid accessing a disposed instance of it.

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
Fixes #117 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
