### PR TITLE
Fix regression preventing Hud to display more than once

### DIFF
--- a/BTProgressHUD/ProgressHUD.cs
+++ b/BTProgressHUD/ProgressHUD.cs
@@ -774,7 +774,6 @@ namespace BigTed
             try
             {
                 HudWindow?.RootViewController?.SetNeedsStatusBarAppearanceUpdate();
-                HudWindow = null!;
             }
             catch (ObjectDisposedException)
             {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
After fist dismiss HudWindow gets nulled out and does not allow any more huds to be displayed for that Window as a ProgressHud reference is being kept per Window.
Since many phone Apps are single Window, then the ProgressHud will stop working if its internal reference to the HudWindow is nulled out.

This regression was introduced in #117 

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing
Call any Show() method multiple times

### :memo: Links to relevant issues/docs
#117 
Fixes #121 

### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
